### PR TITLE
Show events on the same day

### DIFF
--- a/app/scripts/plugin.js
+++ b/app/scripts/plugin.js
@@ -196,6 +196,9 @@ Timetable.Renderer = function(tt) {
 			function computeEventBlockOffset(event) {
 				var start = event.startDate;
 				var startHours = start.getHours() + (start.getMinutes() / 60);
+                                if (startHours < timetable.scope.hourStart) {
+                                  startHours += 24; // Show Events on the same Night
+                                }
 				return (startHours - timetable.scope.hourStart) / scopeDurationHours * 100 + '%';
 			}
 


### PR DESCRIPTION
This fixes a bug where events placed after midnight would not appear if the scope is set very late:
```javascript
timetable.setScope(18, 3);
```