### PR TITLE
15 sticky header

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,9 @@ insert_final_newline = true
 [*.md]
 trim_trailing_whitespace = false
 
+[*.sass]
+indent_style = tab
+
 [{package,bower}.json]
 indent_style = space
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -61,11 +61,14 @@ That's it!
 ## Changing the looks
 Instead of adding the `timetablejs.css` directly to your HTML, you could import `app/styles/plugin.sass` to your own SASS file. All colors and spacing values are defined as default variables which you can easily override. These are the defaults:
 ```sass
+// general
+$timetable-use-sticky-header: false !default
+
 // dimensions
 $timetable-hour-column-width: 96px !default
 $timetable-hour-row-height: 46px !default
 $timetable-heading-height: 30px !default
-$timetable-breakpoint: "only screen and (max-width: 960px)" !default
+
 // colors & decoration
 $timetable-grid-color: #E5E5E5 !default
 $timetable-grid: 1px solid $timetable-grid-color !default
@@ -80,7 +83,10 @@ $timetable-entry-color: #EC6A5E !default
 $timetable-entry-color-hover: darken($timetable-entry-color, 10%) !default
 $timetable-entry-border: 1px solid darken($timetable-entry-color, 15%) !default
 $timetable-entry-padding: 10px !default
+$timetable-background-color: white !default
 ```
+
+The option `$timetable-use-sticky-header` makes the time indicator stick to the top of the screen while scrolling down, which can be very pleasant with large timetables or on mobile devices. Note that this is not yet widely supported in browsers, although all modern (non-IE) browsers support it. Browsers that don't support it will fall back to a non-sticky header automatically. [More info here](https://caniuse.com/#feat=css-sticky). 
 
 Alternatively you could override the css styles manually.
 

--- a/app/demo.html
+++ b/app/demo.html
@@ -22,6 +22,7 @@
     <div class="timetable"></div>
 
     <!-- build:js scripts/timetable.js -->
+    <script src="syncscroll/syncscroll.js"></script>
     <script src="scripts/plugin.js"></script>
     <!-- endbuild -->
 

--- a/app/scripts/plugin.js
+++ b/app/scripts/plugin.js
@@ -131,13 +131,18 @@ Timetable.Renderer = function(tt) {
 				}
 			}
 			function appendTimetableSection(container) {
-				var sectionNode = container.appendChild(document.createElement('section'));
+        var sectionNode = container.appendChild(document.createElement('section'));
+				var headerNode = appendColumnHeaders(sectionNode);
 				var timeNode = sectionNode.appendChild(document.createElement('time'));
-				appendColumnHeaders(timeNode);
-				appendTimeRows(timeNode);
+        timeNode.className = 'syncscroll';
+        timeNode.setAttribute('name', 'scrollheader');
+        var width = headerNode.scrollWidth + 'px';
+				appendTimeRows(timeNode, width);
 			}
 			function appendColumnHeaders(node) {
 				var headerNode = node.appendChild(document.createElement('header'));
+				headerNode.className = 'syncscroll';
+        headerNode.setAttribute('name', 'scrollheader');
 				var headerULNode = headerNode.appendChild(document.createElement('ul'));
 
 				var completed = false;
@@ -157,9 +162,11 @@ Timetable.Renderer = function(tt) {
 						looped = true;
 					}
 				}
+				return headerNode;
 			}
-			function appendTimeRows(node) {
+			function appendTimeRows(node, width) {
 				var ulNode = node.appendChild(document.createElement('ul'));
+        ulNode.style.width = width;
 				ulNode.className = 'room-timeline';
 				for (var k=0; k<timetable.locations.length; k++) {
 					var liNode = ulNode.appendChild(document.createElement('li'));

--- a/app/styles/demo.sass
+++ b/app/styles/demo.sass
@@ -1,5 +1,4 @@
 body
-  background: #fcfcfc
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif
   color: #333
   font-size: 15px

--- a/app/styles/plugin.sass
+++ b/app/styles/plugin.sass
@@ -5,6 +5,9 @@
  * Default settings
  * ==========================================================================
 
+// general
+$timetable-use-sticky-header: false !default
+
 // dimensions
 $timetable-hour-column-width: 96px !default
 $timetable-hour-row-height: 46px !default
@@ -101,7 +104,7 @@ $timetable-background-color: white !default
 			display: block
 			background-color: $timetable-background-color
 			height: $timetable-hour-row-height
-			position: sticky
+			position: if($timetable-use-sticky-header, sticky, relative)
 			margin-top: - $timetable-hour-row-height
 			top: 0
 
@@ -120,7 +123,7 @@ $timetable-background-color: white !default
 			-webkit-overflow-scrolling: touch
 
 		> header
-			position: sticky
+			position: if($timetable-use-sticky-header, sticky, relative)
 			top: 0
 			z-index: 3
 			width: 100%

--- a/app/styles/plugin.sass
+++ b/app/styles/plugin.sass
@@ -60,26 +60,25 @@ $timetable-entry-padding: 10px !default
 .timetable
 	text-align: center
 	display: flex
-	flex-direction: row
 	align-items: stretch
 	width: 100%
-
+	max-width: 100%
 	box-sizing: border-box
 
-	+clearfix
-
-	*, *:before, *:after
+	*
 		box-sizing: inherit
+
+	ul
+		list-style-type: none
+		margin: 0
 
 	ul, li
 		margin: 0
 		padding: 0
 		list-style-type: none
 
-	aside, section
-		float: left
-
-	aside
+	> aside
+		flex: 0
 		max-width: 30%
 		padding: 0 !important
 		margin-top: $timetable-hour-row-height
@@ -95,56 +94,59 @@ $timetable-entry-padding: 10px !default
 		.row-heading
 			+ellipsis
 
-	ul
-		list-style-type: none
-		margin: 0
-
 	aside li, time li
 		height: $timetable-hour-row-height
 
-	section
-		flex-grow: 1
+	> section
+		flex: 3 0 0
+		width: 0
 		padding: 0 !important
-		overflow-x: scroll
-		-webkit-overflow-scrolling: touch
 
 		time
-			white-space: nowrap
-			display: inline-block
+			display: block
+			width: 100%
+			overflow-x: scroll
+			-webkit-overflow-scrolling: touch
 
-		header
+		> header
+			position: sticky
+			top: 0
+			z-index: 2
+			width: 100%
+			overflow: hidden
 			height: $timetable-hour-row-height
 			transform-style: preserve-3d
-			+clearfix
-			font-size: 0
+			display: flex
+			white-space: nowrap
+
 			li
 				display: inline-block
-				font-size: 1rem
 				overflow: visible
-				width: 0
 				line-height: $timetable-hour-row-height
-				display: inline-block
 				position: relative
+				width: $timetable-hour-column-width
 
-				&:not(:last-of-type)
-					width: $timetable-hour-column-width
 				.time-label
 					display: block
 					position: absolute
 					left: 0
 				&:not(:first-of-type) .time-label
 					transform: translateX(-50%)
-				&:last-of-type .time-label
-					transform: translateX(-100%)
+				&:last-of-type
+					width: 0
+					.time-label
+						transform: translateX(-100%)
 
 	ul.room-timeline
 		border-left: none
-		position: relative
-		overflow: hidden
+		display: flex
+		flex-direction: column
+		align-items: stretch
 
 		li
 			position: relative
 			background-color: $timetable-row-even-color
+			height: $timetable-hour-row-height
 			&:nth-of-type(odd)
 				background-color: $timetable-row-uneven-color
 			&:first-of-type
@@ -176,7 +178,7 @@ $timetable-entry-padding: 10px !default
 		transition: 200ms background-color
 		height: $timetable-hour-row-height - 1px
 		display: block
-		position: absolute
+		position: relative
 		z-index: 2
 		padding: 0 $timetable-entry-padding
 		white-space: normal

--- a/app/styles/plugin.sass
+++ b/app/styles/plugin.sass
@@ -24,6 +24,7 @@ $timetable-entry-color: #EC6A5E !default
 $timetable-entry-color-hover: darken($timetable-entry-color, 10%) !default
 $timetable-entry-border: 1px solid darken($timetable-entry-color, 15%) !default
 $timetable-entry-padding: 10px !default
+$timetable-background-color: white !default
 
 /* ==========================================================================
  * Mixins
@@ -78,11 +79,12 @@ $timetable-entry-padding: 10px !default
 		list-style-type: none
 
 	> aside
-		flex: 0
+		flex: none
 		max-width: 30%
 		padding: 0 !important
 		margin-top: $timetable-hour-row-height
 		border-right: $timetable-row-header-gap
+		position: relative
 		li
 			padding: 0 $timetable-row-header-padding
 			background-color: $timetable-row-header-color
@@ -94,11 +96,20 @@ $timetable-entry-padding: 10px !default
 		.row-heading
 			+ellipsis
 
+		&::before
+			content: ''
+			display: block
+			background-color: $timetable-background-color
+			height: $timetable-hour-row-height
+			position: sticky
+			margin-top: - $timetable-hour-row-height
+			top: 0
+
 	aside li, time li
 		height: $timetable-hour-row-height
 
 	> section
-		flex: 3 0 0
+		flex: 3 0 auto
 		width: 0
 		padding: 0 !important
 
@@ -111,18 +122,20 @@ $timetable-entry-padding: 10px !default
 		> header
 			position: sticky
 			top: 0
-			z-index: 2
+			z-index: 3
 			width: 100%
 			overflow: hidden
-			height: $timetable-hour-row-height
+			background-color: $timetable-background-color
 			transform-style: preserve-3d
-			display: flex
-			white-space: nowrap
+
+			ul
+				display: flex
+				height: $timetable-hour-row-height
+				align-items: center
 
 			li
-				display: inline-block
-				overflow: visible
-				line-height: $timetable-hour-row-height
+				flex: none
+				display: block
 				position: relative
 				width: $timetable-hour-column-width
 

--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
   "main": [
     "dist/scripts/timetable.js",
     "dist/styles/timetablejs.css"
-  ]
+  ],
+  "dependencies": {
+    "syncscroll": "^0.0.3"
+  }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('jshint', function () {
 });
 
 gulp.task('html', ['styles'], function () {
-  var assets = $.useref.assets({searchPath: ['.tmp', 'app', '.']});
+  var assets = $.useref.assets({searchPath: ['.tmp', 'app', '.', 'bower_components']});
 
   return gulp.src('app/*.html')
     .pipe(assets)
@@ -76,7 +76,7 @@ gulp.task('serve', ['styles'], function () {
     notify: false,
     port: 9000,
     server: {
-      baseDir: ['.tmp', 'app'],
+      baseDir: ['.tmp', 'app', 'bower_components'],
       index: 'demo.html',
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,9 +838,13 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.3.0, commander@^2.9.0:
+commander@^2.3.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+
+commander@^2.9.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
 
 commander@~2.8.1:
   version "2.8.1"
@@ -2568,8 +2572,8 @@ homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
 
 html-comment-regex@^1.1.0:
   version "1.1.1"
@@ -3543,8 +3547,8 @@ lru-cache@2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
 lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -4663,9 +4667,21 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.2.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -4757,8 +4773,8 @@ replace-ext@^1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request@2:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  version "2.85.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -5226,8 +5242,8 @@ squeak@^1.0.0:
     lpad-align "^1.0.1"
 
 sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"


### PR DESCRIPTION
Adds an optional sticky header to timetablejs (#15). The top bar which includes the time indicators will move along while scrolling, and disappear from the screen when scrolling beyond the timetable.

Note that this implementation is based on a CSS draft which is not yet widely supported in browsers, although all modern (non-IE) browsers support it. [More info here](https://caniuse.com/#feat=css-sticky).

To reach this, I had to swap around a bit in the DOM structure, and add a helper plugin to scroll the position of the header based on the horizontal scroll position of the timetable itself. This is due to complexity of using a partly "fixed" element within a scrollable container. This is not supported by the css *sticky* specification itself.

Note also that this may not work inside parent elements with an `overflow` other than `visible`.